### PR TITLE
Replace deprecated ssl.wrap_socket function

### DIFF
--- a/2a - Examining IP Addressing/examining_ip.py
+++ b/2a - Examining IP Addressing/examining_ip.py
@@ -128,7 +128,7 @@ else:
 
 
 # Wrap the socket in an SSL/TLS context
-tls_sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLS)
+tls_sock = ssl.SSLContext(ssl.PROTOCOL_TLS).wrap_socket(sock)
 
 # Connect to the server
 tls_sock.connect((url_Entered, port))

--- a/4  - Client to Web Server (IP, port numbers, NAT, GET, Response)/client-server-ip-port-socket-httpsresponse.py
+++ b/4  - Client to Web Server (IP, port numbers, NAT, GET, Response)/client-server-ip-port-socket-httpsresponse.py
@@ -128,7 +128,7 @@ else:
 
 
 # Wrap the socket in an SSL/TLS context
-tls_sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLS)
+tls_sock = ssl.SSLContext(ssl.PROTOCOL_TLS).wrap_socket(sock)
 
 # Connect to the server
 tls_sock.connect((url_Entered, port))

--- a/5 - Client to Web Server (TCP 3-way handshake)/tcp-3-way-ask-url-https.py
+++ b/5 - Client to Web Server (TCP 3-way handshake)/tcp-3-way-ask-url-https.py
@@ -115,7 +115,7 @@ else:
  
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)   
 
-s = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLS)
+s = ssl.SSLContext(ssl.PROTOCOL_TLS).wrap_socket(sock)
 
 s.connect(("8.8.8.8", 443))
 #print(s.getsockname()[0])
@@ -124,7 +124,7 @@ s.connect(("8.8.8.8", 443))
 port = 443
 
 # Wrap the socket in an SSL/TLS context
-s = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLS)
+s = ssl.SSLContext(ssl.PROTOCOL_TLS).wrap_socket(sock)
 
 # Connect to the server
 s.connect((url_Entered, port))


### PR DESCRIPTION
# Replace deprecated ssl.wrap_socket function

## Description
The ssl.wrap_socket function is deprecated in Python 3.7 and removed in Python 3.12.
Trying to run programs using this method in Python 3.12 will result in a fatal error.

## Reproduction
Run e.g. "2a - Examining IP Addressing/examining_ip.py"

## Error
```
Traceback (most recent call last):
  File "c:\...\Python-TCPIP\2a - Examining IP Addressing\examining_ip.py", line 131, in <module>
    tls_sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLS)
               ^^^^^^^^^^^^^^^
AttributeError: module 'ssl' has no attribute 'wrap_socket'
```

## Solution
Create a ssl.SSLContext object and call its ssl.SSLContext.wrap_socket method instead.

## Reference
https://docs.python.org/3.12/whatsnew/3.12.html#ssl
